### PR TITLE
ナビバーの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,3 +39,9 @@
 .alert-alert {
   @extend .alert-danger;
 }
+
+// body
+
+body {
+  padding-top: 56px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,5 +43,5 @@
 // body
 
 body {
-  padding-top: 56px;
+  padding-top: 69px;
 }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,9 +1,41 @@
-<% if user_signed_in? %>
-  <%# ログイン時 %>
-  <%= link_to "アカウント編集", edit_user_registration_path %>
-  <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %>
-<% else %>
-  <%# 非ログイン時 %>
-  <%= link_to "新規登録", new_user_registration_path %>
-  <%= link_to "ログイン", new_user_session_path %>
-<% end %>
+<nav class="navbar navbar-expand-md navbar-dark bg-primary fixed-top">
+  <%= link_to image_tag("yanbaru_expert_logo.png"), root_path, class: "navbar-brand" %>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarSupportedContent">
+    <ul class="navbar-nav mr-auto">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Ruby
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <%= link_to "Ruby/Railsテキスト教材", texts_path, class: "dropdown-item" %>
+          <%= link_to "Ruby/Rails動画教材", movies_path, class: "dropdown-item" %>
+        </div>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle active" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          PHP
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <%= link_to "PHPテキスト教材", texts_path, class: "dropdown-item" %>
+          <%= link_to "PHP動画教材", movies_path, class: "dropdown-item" %>
+        </div>
+      </li>
+      <% if user_signed_in? %>
+        <%# ログイン時 %>
+        <li class="nav-item">
+        <%= link_to "アカウント編集", edit_user_registration_path, class: "nav-item nav-link active" %>
+        <li class="nav-item">
+        <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" }, class: "nav-item nav-link active" %>
+      <% else %>
+        <%# 非ログイン時 %>
+        <li class="nav-item">
+        <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
+        <li class="nav-item">
+        <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
+      <% end %>
+    </ul>
+  </div>
+</nav>


### PR DESCRIPTION
close #11

## 実装内容

- Bootstrapを利用してナビバーを作成
  - `.fixed-top` を使用して上に固定
  - リンクは `link_to` ヘルパーメソッドを使用
  - `md` サイズ未満で「ハンバーガーメニュー」に切り替わるように設定

- コンテンツがヘッダーに隠れないように調整

## 参考資料

- [【公式】Bootstrap（Navbar）](https://getbootstrap.jp/docs/4.5/components/navbar/)
- [【やんばるエキスパート教材】メッセージ投稿アプリ（その3・Bootstrap）](https://www.yanbaru-code.com/texts/271)
- [【やんばるエキスパート教材】画像ファイルが表示されない](https://www.yanbaru-code.com/questions/59)

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行