### PR TITLE
Rails動画教材ページの実装

### DIFF
--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -1,0 +1,12 @@
+.card-box {
+  margin: 0 auto;
+}
+
+.card-body {
+  height: 180px;
+  margin: 0 auto;
+}
+
+.btn {
+  width: 100%;
+}

--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -1,7 +1,3 @@
-.card-box {
-  margin: 0 auto;
-}
-
 .card-body {
   height: 180px;
   margin: 0 auto;

--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -2,7 +2,3 @@
   height: 180px;
   margin: 0 auto;
 }
-
-.btn {
-  width: 100%;
-}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,3 +1,5 @@
 class MoviesController < ApplicationController
-  def index; end
+  def index
+    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -13,4 +13,6 @@ class Movie < ApplicationRecord
     rails: 4,
     php: 5
   }
+
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 end

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,0 +1,13 @@
+<div class="card-box col-12 col-md-6 col-lg-4">
+  <div class="card border-dark mb-3">
+    <div class="card-header p-0">
+      <div class="embed-responsive embed-responsive-16by9">
+        <iframe class="embed-responsive-item" src="<%= movie.url %>" allowfullscreen></iframe>
+      </div>
+      <div class="card-body text-dark movie-body">
+        <a href="#" class="btn btn-secondary">読破済みにする</a>
+        <p class="card-title mt-4"><%= "Lv.#{movie_counter + 1} : #{movie.title}" %></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -5,7 +5,7 @@
         <iframe class="embed-responsive-item" src="<%= movie.url %>" allowfullscreen></iframe>
       </div>
       <div class="card-body text-dark movie-body">
-        <a href="#" class="btn btn-secondary">読破済みにする</a>
+        <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>
         <p class="card-title mt-4"><%= "Lv.#{movie_counter + 1} : #{movie.title}" %></p>
       </div>
     </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,1 +1,10 @@
-
+<div class="container">
+  <h1 class="text-center mt-2 mb-4">
+    Ruby/Rails
+    <br class="d-sm-none">
+    動画
+  </h1>
+  <div class="row">
+    <%= render partial: "movie", collection: @movies %>
+  </div>
+</div>


### PR DESCRIPTION
close #15

## 実装内容

- モデルにRailsジャンルリストを定義
- Rails動画教材の一覧ページを作成
  - 表示するジャンルを制限
  - レンダリングを使用
  - Bootstrap用いてレイアウトを作成
  - 各動画にレベル表示を入れる
  - カードの下側部分に`height` を指定し高さを揃える
  - 動画教材専用のcssを作成し、実装

## 参考資料

- [【公式】Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
- [【公式】Bootstrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)
- [【公式】Embeds](https://getbootstrap.com/docs/4.5/utilities/embed/)
- [【やんばるエキスパート教材】YouTube動画の投稿](https://www.yanbaru-code.com/texts/349)
- [Railsのpartialでcollectionを渡すときにはindexの変数が自動的に作られる](https://qiita.com/otakumesi/items/74a75cd6ebff7eba5c63)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
