### PR TITLE
動画教材の読破済み機能

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,6 @@
 class MoviesController < ApplicationController
   PER_PAGE = 12
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(PER_PAGE)
+    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(PER_PAGE).includes(:watch_progresses)
   end
 end

--- a/app/controllers/watch_progresses_controller.rb
+++ b/app/controllers/watch_progresses_controller.rb
@@ -1,11 +1,11 @@
 class WatchProgressesController < ApplicationController
   def create
-    @movie = Movie.find(params[movie_id])
+    @movie = Movie.find(params[:movie_id])
     current_user.watch_progresses.create!(movie_id: @movie.id)
   end
 
   def destroy
-    @movie = Movie.find(params[movie_id])
+    @movie = Movie.find(params[:movie_id])
     current_user.watch_progresses.find_by(movie_id: @movie.id).destroy!
   end
 end

--- a/app/controllers/watch_progresses_controller.rb
+++ b/app/controllers/watch_progresses_controller.rb
@@ -1,0 +1,11 @@
+class WatchProgressesController < ApplicationController
+  def create
+    @movie = Movie.find(params[movie_id])
+    current_user.watch_progresses.create!(movie_id: @movie.id)
+  end
+
+  def destroy
+    @movie = Movie.find(params[movie_id])
+    current_user.watch_progresses.find_by(movie_id: @movie.id).destroy!
+  end
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,4 +1,6 @@
 class Movie < ApplicationRecord
+  has_many :watch_progresses, dependent: :destroy
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,6 +1,10 @@
 class Movie < ApplicationRecord
   has_many :watch_progresses, dependent: :destroy
 
+  def watch_progressed_by?(user)
+    watch_progresses.any? { |watch_progress| watch_progress.user_id == user.id }
+  end
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :watch_progresses, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/watch_progress.rb
+++ b/app/models/watch_progress.rb
@@ -1,0 +1,4 @@
+class WatchProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :movie
+end

--- a/app/models/watch_progress.rb
+++ b/app/models/watch_progress.rb
@@ -1,4 +1,8 @@
 class WatchProgress < ApplicationRecord
   belongs_to :user
   belongs_to :movie
+  validates :user_id, uniqueness: {
+    scope: :movie_id,
+    message: "は同じ動画教材を2回以上視聴済みにはできません"
+  }
 end

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -5,7 +5,13 @@
         <iframe class="embed-responsive-item" src="<%= movie.url %>" allowfullscreen></iframe>
       </div>
       <div class="card-body text-dark movie-body">
-        <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>
+        <p id="movie-<%= movie.id %>">
+          <% if movie.watch_progressed_by?(current_user) %>
+            <%= render "watch", movie: movie %>
+          <% else %>
+            <%= render "unwatch", movie: movie %>
+          <% end %>
+        </p>
         <p class="card-title mt-4"><%= "Lv.#{movie_counter + @movies.offset_value + 1} : #{movie.title}" %></p>
       </div>
     </div>

--- a/app/views/movies/_unwatch.html.erb
+++ b/app/views/movies/_unwatch.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "視聴済みにする", movie_watch_progresses_path(movie), class: "btn btn-secondary btn-block", method: :post, remote: true %>

--- a/app/views/movies/_watch.html.erb
+++ b/app/views/movies/_watch.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "視聴済みを解除", movie_watch_progresses_path(movie),  class: "btn btn-primary btn-block", method: :delete, remote: true %>

--- a/app/views/watch_progresses/create.js.erb
+++ b/app/views/watch_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('movie-<%= @movie.id %>').innerHTML = '<%= j render("movies/watch", movie: @movie) %>'

--- a/app/views/watch_progresses/destroy.js.erb
+++ b/app/views/watch_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('movie-<%= @movie.id %>').innerHTML = '<%= j render("movies/unwatch", movie: @movie) %>'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       text: テキスト教材
       movie: 動画教材
+      watch_progress: 視聴済み
     attributes:
       text:
         genre: ジャンル

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,9 @@ ja:
         genre: ジャンル
         title: タイトル
         url: URL
+      watch_progress:
+        user: ユーザー
+        movie: 動画教材
 
   attributes:
     id: ID

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,7 @@ Rails.application.routes.draw do
   end
   root "texts#index"
   resources :texts, only: [:index, :show]
-  resources :movies, only: :index
+  resources :movies, only: [:index] do
+    resource :watch_progresses, only: [:create, :destroy]
+  end
 end

--- a/db/migrate/20210811110544_create_watch_progresses.rb
+++ b/db/migrate/20210811110544_create_watch_progresses.rb
@@ -1,0 +1,10 @@
+class CreateWatchProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :watch_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :movie, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210811110544_create_watch_progresses.rb
+++ b/db/migrate/20210811110544_create_watch_progresses.rb
@@ -6,5 +6,6 @@ class CreateWatchProgresses < ActiveRecord::Migration[6.1]
 
       t.timestamps
     end
+    add_index :watch_progresses, [:user_id, :movie_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_22_013330) do
+ActiveRecord::Schema.define(version: 2021_08_11_110544) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,4 +66,16 @@ ActiveRecord::Schema.define(version: 2021_07_22_013330) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  create_table "watch_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "movie_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["movie_id"], name: "index_watch_progresses_on_movie_id"
+    t.index ["user_id", "movie_id"], name: "index_watch_progresses_on_user_id_and_movie_id", unique: true
+    t.index ["user_id"], name: "index_watch_progresses_on_user_id"
+  end
+
+  add_foreign_key "watch_progresses", "movies"
+  add_foreign_key "watch_progresses", "users"
 end


### PR DESCRIPTION
close #23

## 実装内容

- 視聴済み機能に使用する`WatchProgress`モデルを作成
  - 外部キー設定を行い、ユニーク制約を入れてマイグレーション
  - バリデーションをモデルに追加
  - 関連付けを入れる
  - `WatchProgress`モデルに関する日本語訳を追加
- 動画教材一覧ページに視聴済み機能を実装
  - 非同期で処理する機能を追加
  - n＋1問題の解消
  - 動作確認

## 参考資料

- [【やんばるエキスパート教材】モデルの関連付け その2（多対多）](https://www.yanbaru-code.com/texts/297)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## 備考

- 動画教材なので、「読破済み」ボタンを「視聴済み」ボタンに変更しました。