### PR TITLE
動画教材ページのジャンル分け

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,6 @@
 class MoviesController < ApplicationController
   PER_PAGE = 12
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(PER_PAGE)
+    @movies = Movie.where(genre: Movie.genre_list(params[:genre])).page(params[:page]).per(PER_PAGE)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,8 @@ module ApplicationHelper
       "mw-xl"
     end
   end
+
+  def title
+    params[:genre] == "php" ? "PHP" : "Ruby/Rails"
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -14,5 +14,7 @@ class Movie < ApplicationRecord
     php: 5
   }
 
-  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+  def self.genre_list(genre)
+    genre == "php" ? %w[php] : %w[basic git ruby rails]
+  end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -20,23 +20,28 @@
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
           <%= link_to "PHPテキスト教材", texts_path, class: "dropdown-item" %>
-          <%= link_to "PHP動画教材", movies_path, class: "dropdown-item" %>
+          <%= link_to "PHP動画教材", movies_path(genre: "php"), class: "dropdown-item" %>
         </div>
       </li>
       <% if user_signed_in? %>
         <%# ログイン時 %>
         <li class="nav-item">
-        <%= link_to "アカウント編集", edit_user_registration_path, class: "nav-item nav-link active" %>
+          <%= link_to "アカウント編集", edit_user_registration_path, class: "nav-item nav-link active" %>
+        </li>
         <li class="nav-item">
-        <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" }, class: "nav-item nav-link active" %>
+          <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" }, class: "nav-item nav-link active" %>
+        </li>
       <% else %>
         <%# 非ログイン時 %>
         <li class="nav-item">
-        <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
+          <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
+        </li>
         <li class="nav-item">
-        <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
+          <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
+        </li>
         <li class="nav-item">
-        <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "nav-item nav-link active" %>
+          <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "nav-item nav-link active" %>
+        </li>
       <% end %>
     </ul>
   </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,6 +1,6 @@
 <div class="base-container">
   <h1 class="text-center mt-2 mb-4">
-    Ruby/Rails
+    <%= title %>
     <br class="d-sm-none">
     動画
   </h1>
@@ -8,5 +8,4 @@
     <%= render partial: "movie", collection: @movies %>
   </div>
 </div>
-
 <%= paginate @movies %>


### PR DESCRIPTION
close #18 

## 実装内容

- PHP動画教材ページで「PHPの動画教材のみ」が表示されるように修正
- 動画教材ページのタイトルを修正

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行