### PR TITLE
テキスト教材ページのジャンル分け

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    @texts = Text.where(genre: Text.genre_list(params[:genre]))
   end
 
   def show; end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -14,5 +14,7 @@ class Text < ApplicationRecord
     php: 5
   }
 
-  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+  def self.genre_list(genre)
+    genre == "php" ? %w[php] : %w[basic git ruby rails]
+  end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -19,7 +19,7 @@
           PHP
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-          <%= link_to "PHPテキスト教材", texts_path, class: "dropdown-item" %>
+          <%= link_to "PHPテキスト教材", texts_path(genre: "php"), class: "dropdown-item" %>
           <%= link_to "PHP動画教材", movies_path(genre: "php"), class: "dropdown-item" %>
         </div>
       </li>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,6 +1,6 @@
 <div class="base-container">
   <h1 class="text-center mt-2 mb-4">
-    Ruby/Rails
+    <%= title %>
     <br class="d-sm-none">
      テキスト教材
   </h1>


### PR DESCRIPTION
close #20

## 実装内容

- PHPテキスト教材ページで「PHPのテキスト教材のみ」が表示されるように修正
- 「Ruby/Railsテキスト教材ページ」のタイトルは「Ruby/Rails テキスト教材」，「PHPテキスト教材ページ」のタイトルは「PHP テキスト教材」とする

## 参考資料（必要があれば）

#18 動画教材ページのジャンル分け

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## 備考

はじめにブランチを切り替えるのを忘れ、developで作業を行ってしまいました。
2回コミットした後にブランチの切り替えを行い、新しいブランチにコミットをコピーし、developのコミットは削除して対応したつもりです。
その点もご確認お願い致します。